### PR TITLE
feat: add hover state to review stars

### DIFF
--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -351,44 +351,34 @@ class _ReviewDialogState extends State<_ReviewDialog> {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              PannableRatingBar(
-                rate: _hoverRating ?? 0,
-                spacing: 5,
-                onChanged: setRating,
-                onHover: updateRating,
-                items: List.generate(
-                  5,
-                  (_) => const RatingWidget(
-                    selectedColor: kStarColor,
-                    unSelectedColor: Colors.grey,
-                    child: Icon(
-                      YaruIcons.star_filled,
-                      // color: kStarColor,
-                      size: 40,
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                onExit: (event) => setState(() {
+                  _hoverRating = _reviewRating;
+                }),
+                child: PannableRatingBar(
+                  rate: _hoverRating ?? 0,
+                  minRating: 1,
+                  maxRating: 5,
+                  spacing: 5,
+                  onChanged: setRating,
+                  onHover: updateRating,
+                  valueTransformer: (value) => value.ceilToDouble(),
+                  items: List.generate(
+                    5,
+                    (_) => RatingWidget(
+                      selectedColor: kStarColor,
+                      unSelectedColor: theme.brightness == Brightness.light
+                          ? const Color(0xffd4d4d4)
+                          : const Color(0xff545454),
+                      child: const Icon(
+                        YaruIcons.star_filled,
+                        size: 40,
+                      ),
                     ),
                   ),
                 ),
               ),
-              // RatingBar.builder(
-              //   initialRating: _reviewRating ?? 0,
-              //   minRating: 1,
-              //   direction: Axis.horizontal,
-              //   itemCount: 5,
-              //   itemPadding: const EdgeInsets.only(right: 5),
-              //   itemSize: 40,
-              //   itemBuilder: (context, _) => const MouseRegion(
-              //     cursor: SystemMouseCursors.click,
-              //     child: Icon(
-              //       YaruIcons.star_filled,
-              //       color: kStarColor,
-              //       size: 2,
-              //     ),
-              //   ),
-              //   unratedColor: theme.colorScheme.onSurface.withOpacity(0.2),
-              //   onRatingUpdate: (rating) {
-              //     setState(() => _reviewRating = rating);
-              //   },
-              // ),
             ],
           ),
           const SizedBox(

--- a/lib/app/common/app_page/app_reviews.dart
+++ b/lib/app/common/app_page/app_reviews.dart
@@ -2,7 +2,8 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_rating_bar/flutter_rating_bar.dart';
+import 'package:flutter_pannable_rating_bar/flutter_pannable_rating_bar.dart';
+import 'package:flutter_rating_bar/flutter_rating_bar.dart' hide RatingWidget;
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:software/app/common/app_data.dart';
@@ -298,6 +299,20 @@ class _ReviewDialog extends StatefulWidget {
 
 class _ReviewDialogState extends State<_ReviewDialog> {
   double? _reviewRating;
+  double? _hoverRating;
+
+  void updateRating(double value) {
+    setState(() {
+      _hoverRating = value;
+    });
+  }
+
+  void setRating(double value) {
+    setState(() {
+      _reviewRating = value;
+    });
+  }
+
   final _reviewController = TextEditingController();
   final _reviewTitleController = TextEditingController();
 
@@ -336,26 +351,44 @@ class _ReviewDialogState extends State<_ReviewDialog> {
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              RatingBar.builder(
-                initialRating: _reviewRating ?? 0,
-                minRating: 1,
-                direction: Axis.horizontal,
-                itemCount: 5,
-                itemPadding: const EdgeInsets.only(right: 5),
-                itemSize: 40,
-                itemBuilder: (context, _) => const MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  child: Icon(
-                    YaruIcons.star_filled,
-                    color: kStarColor,
-                    size: 2,
+              PannableRatingBar(
+                rate: _hoverRating ?? 0,
+                spacing: 5,
+                onChanged: setRating,
+                onHover: updateRating,
+                items: List.generate(
+                  5,
+                  (_) => const RatingWidget(
+                    selectedColor: kStarColor,
+                    unSelectedColor: Colors.grey,
+                    child: Icon(
+                      YaruIcons.star_filled,
+                      // color: kStarColor,
+                      size: 40,
+                    ),
                   ),
                 ),
-                unratedColor: theme.colorScheme.onSurface.withOpacity(0.2),
-                onRatingUpdate: (rating) {
-                  setState(() => _reviewRating = rating);
-                },
               ),
+              // RatingBar.builder(
+              //   initialRating: _reviewRating ?? 0,
+              //   minRating: 1,
+              //   direction: Axis.horizontal,
+              //   itemCount: 5,
+              //   itemPadding: const EdgeInsets.only(right: 5),
+              //   itemSize: 40,
+              //   itemBuilder: (context, _) => const MouseRegion(
+              //     cursor: SystemMouseCursors.click,
+              //     child: Icon(
+              //       YaruIcons.star_filled,
+              //       color: kStarColor,
+              //       size: 2,
+              //     ),
+              //   ),
+              //   unratedColor: theme.colorScheme.onSurface.withOpacity(0.2),
+              //   onRatingUpdate: (rating) {
+              //     setState(() => _reviewRating = rating);
+              //   },
+              // ),
             ],
           ),
           const SizedBox(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_markdown: ^0.6.10+3
+  flutter_pannable_rating_bar: ^2.7.2+1
   flutter_rating_bar: ^4.0.1
   flutter_svg: ^1.1.0
   glib: 0.0.1


### PR DESCRIPTION
Close #1181

Switched to [flutter_pannable_rating_bar](https://pub.dev/packages/flutter_pannable_rating_bar) for the app_reviews. The rating bars that serve as rating indicators (`ignoreGestures: true`) were left untouched.

flutter_pannable_rating_bar does not support colors with opacity for the unselected star icons at the moment so I had to hardcode the color values based on the app theme.