### PR TITLE
feat: add refresh button to detail page

### DIFF
--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -197,16 +197,18 @@ class _SnapActionButtons extends ConsumerWidget {
                   : l10n.detailPageInstallLabel,
             ),
     );
-    final refreshButton = refreshableSnaps.whenOrNull(
-      data: (snaps) =>
-          snaps.singleWhereOrNull((snap) => snap.name == localSnap!.name) !=
-                  null
-              ? PushButton.elevated(
-                  onPressed: localSnapNotifier.refresh,
-                  child: Text(l10n.detailPageUpdateLabel),
-                )
-              : null,
-    );
+    final refreshButton = localSnap != null
+        ? refreshableSnaps.whenOrNull(
+            data: (snaps) => snaps.singleWhereOrNull(
+                        (snap) => snap.name == localSnap!.name) !=
+                    null
+                ? PushButton.elevated(
+                    onPressed: localSnapNotifier.refresh,
+                    child: Text(l10n.detailPageUpdateLabel),
+                  )
+                : null,
+          )
+        : null;
     final launchButton = snapLauncher?.isLaunchable ?? false
         ? PushButton.outlined(
             onPressed: snapLauncher!.open,

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -8,6 +8,7 @@
     "detailPagePublisherLabel": "Publisher",
     "detailPageSelectChannelLabel": "Select Channel",
     "detailPageSummaryLabel": "Summary",
+    "detailPageUpdateLabel": "Update",
     "detailPageVersionLabel": "Version",
     "detailPageWebsiteLabel": "Website",
     "explorePageLabel": "Explore",

--- a/lib/src/search/search_provider.dart
+++ b/lib/src/search/search_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:snapd/snapd.dart';
 import 'package:ubuntu_service/ubuntu_service.dart';
 
 import '/snapd.dart';
@@ -51,4 +52,9 @@ final sortedSearchProvider =
           _ => 0,
         }));
   });
+});
+
+final refreshProvider = FutureProvider((ref) {
+  final snapd = getService<SnapdService>();
+  return snapd.find(filter: SnapFindFilter.refresh);
 });

--- a/lib/src/snapd/snap_provider.dart
+++ b/lib/src/snapd/snap_provider.dart
@@ -38,6 +38,12 @@ class LocalSnapNotifier extends StateNotifier<LocalSnap> {
     return _getLocalSnap();
   }
 
+  Future<void> refresh() async {
+    state = const LocalSnap.loading();
+    await snapd.refresh(snapName).then(snapd.waitChange);
+    return _getLocalSnap();
+  }
+
   Future<void> remove() async {
     state = const LocalSnap.loading();
     await snapd.remove(snapName).then(snapd.waitChange);

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -190,6 +190,15 @@ class MockLocalSnapNotifier extends _i1.Mock implements _i4.LocalSnapNotifier {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
+  _i6.Future<void> refresh() => (super.noSuchMethod(
+        Invocation.method(
+          #refresh,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
   _i6.Future<void> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,


### PR DESCRIPTION
UDENG-796

- adds `refreshProvider` which provides list of refreshable snaps
- adds a corresponding button to the detail page if the snap is refreshable
- UI questions to figure out:
    * priority of action buttons; which ones will be hidden in a dropdown?
    * how to display snap information if an update is available? version number and metadata can differ between locally installed snap and the latest from the store

I guess we can tackle the UI in a separate issue - the action buttons will just collapse into a column if there's not enough width for now.