### PR TITLE
feat: tweak paddings & geometries

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,13 +3,16 @@ import 'package:flutter/material.dart';
 const kAppName = 'App Store';
 const kGitHubRepo = 'ubuntu/app-store';
 
+const kCardMargin = 4.0;
 const kNaviRailWidth = 205.0;
+const kPagePadding = 16.0;
+const kSearchBarWidth = 424.0 - 2 * kCardMargin;
 
 const kGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
   maxCrossAxisExtent: 550,
   mainAxisExtent: 120,
-  mainAxisSpacing: 12,
-  crossAxisSpacing: 12,
+  mainAxisSpacing: 16 - 2 * kCardMargin,
+  crossAxisSpacing: 16 - 2 * kCardMargin,
 );
 
 // TODO: add proper neutral colors to yaru

--- a/lib/src/about/about_page.dart
+++ b/lib/src/about/about_page.dart
@@ -25,11 +25,11 @@ class AboutPage extends StatelessWidget {
     return CustomScrollView(
       slivers: [
         const SliverPadding(
-          padding: EdgeInsets.all(kYaruPagePadding),
+          padding: EdgeInsets.all(kPagePadding),
           sliver: SliverToBoxAdapter(child: _AboutHeader()),
         ),
         SliverPadding(
-          padding: const EdgeInsets.all(kYaruPagePadding),
+          padding: const EdgeInsets.all(kPagePadding),
           sliver: SliverToBoxAdapter(
             child: Align(
               alignment: AlignmentDirectional.topStart,
@@ -41,13 +41,13 @@ class AboutPage extends StatelessWidget {
           ),
         ),
         const SliverPadding(
-          padding: EdgeInsets.all(kYaruPagePadding),
+          padding: EdgeInsets.all(kPagePadding),
           sliver: SliverToBoxAdapter(child: _CommunityView()),
         ),
         const SliverFillRemaining(
           hasScrollBody: false,
           child: Padding(
-            padding: EdgeInsets.all(kYaruPagePadding),
+            padding: EdgeInsets.all(kPagePadding),
             child: _AboutFooter(),
           ),
         ),

--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -8,6 +8,7 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '/constants.dart';
 import '/l10n.dart';
 import '/search.dart';
 import '/snapd.dart';
@@ -98,13 +99,13 @@ class _SnapView extends ConsumerWidget {
     ];
 
     return SingleChildScrollView(
-      padding: const EdgeInsets.all(kYaruPagePadding),
+      padding: const EdgeInsets.all(kPagePadding),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const YaruBackButton(),
           _Header(snap: storeSnap ?? localSnap),
-          const SizedBox(height: kYaruPagePadding),
+          const SizedBox(height: kPagePadding),
           Row(
             children: [
               Text(
@@ -133,7 +134,7 @@ class _SnapView extends ConsumerWidget {
               )
             ],
           ),
-          const SizedBox(height: kYaruPagePadding),
+          const SizedBox(height: kPagePadding),
           Wrap(
             spacing: 48,
             runSpacing: 8,

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -6,6 +6,7 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '/constants.dart';
 import '/l10n.dart';
 import '/snapd.dart';
 import '/store.dart';
@@ -39,7 +40,7 @@ class _ManageView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     return ListView.builder(
-      padding: const EdgeInsets.all(kYaruPagePadding),
+      padding: const EdgeInsets.all(kPagePadding),
       itemCount: snaps.length,
       itemBuilder: (context, index) {
         final snap = snaps[index];

--- a/lib/src/search/search_page.dart
+++ b/lib/src/search/search_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '/constants.dart';
 import '/l10n.dart';
 import '/store.dart';
 import '/widgets.dart';
@@ -21,7 +22,7 @@ class SearchPage extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.all(kYaruPagePadding),
+          padding: const EdgeInsets.all(kPagePadding),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/lib/src/store/store_app.dart
+++ b/lib/src/store/store_app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '/constants.dart';
 import '/detail.dart';
 import '/l10n.dart';
 import '/search.dart';
@@ -40,7 +41,7 @@ class _StoreAppState extends ConsumerState<StoreApp> {
         home: Scaffold(
           appBar: YaruWindowTitleBar(
             title: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 400),
+              constraints: const BoxConstraints(maxWidth: kSearchBarWidth),
               child: SearchField(
                 onSearch: (query) => _navigator.pushAndRemoveSearch(query),
                 onSelected: (name) => _navigator.pushDetail(name),

--- a/lib/src/widgets/snap_card.dart
+++ b/lib/src/widgets/snap_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
+import '/constants.dart';
 import '/snapd.dart';
 import '/widgets.dart';
 
@@ -14,6 +15,7 @@ class SnapCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return YaruBanner(
+      padding: const EdgeInsets.all(kPagePadding),
       onTap: onTap,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/widgets/snap_grid.dart
+++ b/lib/src/widgets/snap_grid.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
-import 'package:yaru_widgets/constants.dart';
 
 import '/constants.dart';
 import 'snap_card.dart';
@@ -14,7 +13,7 @@ class SnapGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GridView.builder(
-      padding: const EdgeInsets.all(kYaruPagePadding),
+      padding: const EdgeInsets.all(kPagePadding) - const EdgeInsets.all(4),
       gridDelegate: kGridDelegate,
       itemCount: snaps.length,
       itemBuilder: (context, index) {

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -35,7 +35,7 @@ static void my_application_activate(GApplication* application) {
   gtk_window_set_application(window, GTK_APPLICATION(application));
 
   GdkGeometry geometry;
-  geometry.min_width = 660;
+  geometry.min_width = 800;
   geometry.min_height = 600;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
 


### PR DESCRIPTION
`kYaruPagePadding` (20) is not divisible by 8. This PR introduces a local `kPagePadding` (16) constant to make it easier to match things with a layout grid.

NOTE: `YaruBanner` has a hard-coded 4px margin around for the hover effect. This has been taken into account so that the visual spacing between cards becomes 16px.

![image](https://github.com/ubuntu/app-store/assets/140617/c7daa432-7312-46e3-9e5f-bbbfebaa8286)