### PR TITLE
fix(search): reduce icon size

### DIFF
--- a/lib/src/search/search_field.dart
+++ b/lib/src/search/search_field.dart
@@ -122,14 +122,14 @@ class _SearchFieldState extends ConsumerState<SearchField> {
             decoration: InputDecoration(
               contentPadding: const EdgeInsets.fromLTRB(12, 8, 12, 8),
               fillColor: Theme.of(context).dividerColor,
-              prefixIcon: const Icon(YaruIcons.search),
+              prefixIcon: const Icon(YaruIcons.search, size: 16),
               prefixIconConstraints: iconConstraints,
               hintText: l10n.searchFieldSearchHint,
               suffixIcon: AnimatedBuilder(
                 animation: controller,
                 builder: (context, child) {
                   return YaruIconButton(
-                    icon: const Icon(YaruIcons.edit_clear),
+                    icon: const Icon(YaruIcons.edit_clear, size: 16),
                     onPressed:
                         controller.text.isEmpty ? null : controller.clear,
                   );


### PR DESCRIPTION
_Originally posted by @Feichtmeier in https://github.com/ubuntu/app-store/issues/1287#issuecomment-1644088825_

              ((( the search field content padding now makes the icon and the text to be not in one line anymore
![grafik](https://github.com/ubuntu/app-store/assets/15329494/5f353de7-37ff-4bb5-bd74-e6ef2e6ff597)
I guess either change the content padding or decrease icon and text size
)))

| | |
|---|---|
| ![image](https://github.com/ubuntu/app-store/assets/140617/192b7498-b6e9-4069-9899-44bd0d5277b2) | ![image](https://github.com/ubuntu/app-store/assets/140617/c1d7d5a3-2628-419b-93fa-dab2af4d5a31) |