### PR TITLE
feat: implement responsive grid with fixed card sizes

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -4,16 +4,14 @@ const kAppName = 'App Store';
 const kGitHubRepo = 'ubuntu/app-store';
 
 const kCardMargin = 4.0;
-const kNaviRailWidth = 205.0;
+const kNaviRailWidth = 204.0;
 const kPagePadding = 16.0;
 const kSearchBarWidth = 424.0 - 2 * kCardMargin;
+const kIconSize = 56.0;
 
-const kGridDelegate = SliverGridDelegateWithMaxCrossAxisExtent(
-  maxCrossAxisExtent: 550,
-  mainAxisExtent: 120,
-  mainAxisSpacing: 16 - 2 * kCardMargin,
-  crossAxisSpacing: 16 - 2 * kCardMargin,
-);
+const kCardSizeSmall = Size(266.0, 226.0);
+const kCardSizeMedium = Size(332.0, 170.0);
+const kCardSizeLarge = Size(416.0, 170.0);
 
 // TODO: add proper neutral colors to yaru
 const kShimmerBaseLight = Color.fromARGB(120, 228, 228, 228);

--- a/lib/src/widgets/snap_card.dart
+++ b/lib/src/widgets/snap_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
+import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '/constants.dart';
@@ -7,33 +8,65 @@ import '/snapd.dart';
 import '/widgets.dart';
 
 class SnapCard extends StatelessWidget {
-  const SnapCard({super.key, required this.snap, this.onTap});
+  const SnapCard({
+    super.key,
+    required this.snap,
+    this.onTap,
+    this.compact = false,
+  });
 
   final Snap snap;
   final VoidCallback? onTap;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     return YaruBanner(
       padding: const EdgeInsets.all(kPagePadding),
       onTap: onTap,
-      child: Row(
+      child: Flex(
+        direction: compact ? Axis.vertical : Axis.horizontal,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SnapIcon(iconUrl: snap.iconUrl),
-          const SizedBox(width: 16),
+          const SizedBox(width: 16, height: 16),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                SnapTitle(snap: snap),
-                const SizedBox(height: 8),
+                SizedBox(
+                  height: kIconSize,
+                  child: Align(
+                    alignment: Alignment.bottomLeft,
+                    child: SnapTitle(snap: snap),
+                  ),
+                ),
+                const SizedBox(height: 12),
                 Flexible(
                   child: Text(
                     snap.summary,
-                    maxLines: 1,
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
+                ),
+                const SizedBox(height: 8),
+                // TODO: ratings
+                Wrap(
+                  children: [
+                    Text(
+                      'Positive',
+                      style: Theme.of(context).textTheme.bodySmall!.copyWith(
+                            color: Theme.of(context).colorScheme.success,
+                          ),
+                    ),
+                    const SizedBox(width: 2),
+                    Text('|', style: Theme.of(context).textTheme.bodySmall),
+                    const SizedBox(width: 2),
+                    Text(
+                      '200 Ratings',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/src/widgets/snap_grid.dart
+++ b/lib/src/widgets/snap_grid.dart
@@ -12,18 +12,38 @@ class SnapGrid extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GridView.builder(
-      padding: const EdgeInsets.all(kPagePadding) - const EdgeInsets.all(4),
-      gridDelegate: kGridDelegate,
-      itemCount: snaps.length,
-      itemBuilder: (context, index) {
-        final snap = snaps[index];
-        return SnapCard(
-          key: ValueKey(snap.id),
-          snap: snap,
-          onTap: () => onTap(snap),
-        );
-      },
-    );
+    return LayoutBuilder(builder: (context, constraints) {
+      final (columnCount, cardSize) =
+          switch (constraints.maxWidth + kNaviRailWidth + 1) {
+        // 1px for YaruNavigationRail's separator
+        < 1280 => (2, kCardSizeSmall),
+        < 1680 => (3, kCardSizeMedium),
+        _ => (3, kCardSizeLarge),
+      };
+      final columnWidth = columnCount * (cardSize.width + 2 * kCardMargin) +
+          (columnCount - 1) * kPagePadding;
+      return GridView.builder(
+        padding: const EdgeInsets.all(kPagePadding) -
+            const EdgeInsets.all(4) +
+            EdgeInsets.symmetric(
+                horizontal: (constraints.maxWidth - columnWidth) / 2.0),
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: columnCount,
+          childAspectRatio: cardSize.aspectRatio,
+          mainAxisSpacing: kPagePadding,
+          crossAxisSpacing: kPagePadding,
+        ),
+        itemCount: snaps.length,
+        itemBuilder: (context, index) {
+          final snap = snaps[index];
+          return SnapCard(
+            key: ValueKey(snap.id),
+            snap: snap,
+            onTap: () => onTap(snap),
+            compact: cardSize == kCardSizeSmall,
+          );
+        },
+      );
+    });
   }
 }

--- a/lib/src/widgets/snap_icon.dart
+++ b/lib/src/widgets/snap_icon.dart
@@ -10,7 +10,7 @@ class SnapIcon extends StatelessWidget {
   const SnapIcon({
     super.key,
     required this.iconUrl,
-    this.size = 48,
+    this.size = kIconSize,
     this.loadingHighlight,
     this.loadingBaseColor,
   });

--- a/lib/src/widgets/snap_title.dart
+++ b/lib/src/widgets/snap_title.dart
@@ -22,11 +22,12 @@ class SnapTitle extends StatelessWidget {
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     final titleTextStyle =
-        large ? textTheme.headlineLarge! : textTheme.bodyMedium!;
+        large ? textTheme.headlineLarge! : textTheme.titleMedium!;
     final publisherTextStyle =
         large ? textTheme.headlineSmall! : textTheme.bodyMedium!;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
       children: [
         Text(
           snap.titleOrName,


### PR DESCRIPTION
UDENG-1048

Intermediate widths between 800 and 1280 look a bit empty - I'll see if the medium sized cards work better there next week (and maybe a single column for narrow widths).

A weird issue that puzzled me for a bit: even though the minimum window size is set to 800x600 in the GTK app, the window can be resized down to 748x548 - is there an explanation for that difference?

|resolution|screenshot|
|-|-|
|800x600|![Screenshot from 2023-07-21 17-32-22](https://github.com/ubuntu/app-store/assets/113362648/df152b0f-093f-4e7e-a1d3-2ad7a19b22b2)|
|1280x800|![Screenshot from 2023-07-21 17-33-07](https://github.com/ubuntu/app-store/assets/113362648/3c2f4508-c2ef-4643-8b17-17ddfc0078be)|
|1680x1024|![Screenshot from 2023-07-21 17-34-01](https://github.com/ubuntu/app-store/assets/113362648/5d25c977-1dc0-4319-b975-2249d6cf5658)|


