### PR TITLE
feat: responsive detail page

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,15 +3,6 @@ import 'package:flutter/material.dart';
 const kAppName = 'App Store';
 const kGitHubRepo = 'ubuntu/app-store';
 
-const kCardMargin = 4.0;
-const kPaneWidth = 204.0;
-const kPagePadding = 16.0;
-const kSearchBarWidth = 424.0 - 2 * kCardMargin;
-const kIconSize = 56.0;
-
-const kCardSizeNormal = Size(416.0, 170.0);
-const kCardSizeWide = Size(548.0, 170.0);
-
 // TODO: add proper neutral colors to yaru
 const kShimmerBaseLight = Color.fromARGB(120, 228, 228, 228);
 const kShimmerBaseDark = Color.fromARGB(255, 51, 51, 51);

--- a/lib/layout.dart
+++ b/lib/layout.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+const kCardMargin = 4.0;
+const kPaneWidth = 204.0;
+const kPagePadding = 16.0;
+const kSearchBarWidth = 424.0 - 2 * kCardMargin;
+const kIconSize = 56.0;
+
+const kCardSizeNormal = Size(416.0, 170.0);
+const kCardSizeWide = Size(548.0, 170.0);
+
+const kBreakPointSmall = 1280.0;
+const kBreakPointLarge = 1680.0;
+
+class ResponsiveLayout {
+  const ResponsiveLayout({
+    required this.cardColumnCount,
+    required this.cardSize,
+    required this.snapInfoColumnCount,
+    required this.totalWidth,
+  });
+
+  final int cardColumnCount;
+  final Size cardSize;
+  final int snapInfoColumnCount;
+  final double totalWidth;
+
+  factory ResponsiveLayout.fromConstraints(BoxConstraints constraints) {
+    final (cardColumnCount, cardSize, snapInfoColumnCount) =
+        switch (constraints.maxWidth + kPaneWidth + 1) {
+      // 1px for YaruNavigationRail's separator
+      < kBreakPointSmall => (1, kCardSizeWide, 3),
+      < kBreakPointLarge => (2, kCardSizeNormal, 4),
+      _ => (3, kCardSizeNormal, 6),
+    };
+    final totalWidth = cardColumnCount * cardSize.width + // cards
+        (cardColumnCount - 1) * (kPagePadding - 2 * kCardMargin) + // spacing
+        2 * kCardMargin; // left+right margin of outermost cards
+    return ResponsiveLayout(
+      cardColumnCount: cardColumnCount,
+      cardSize: cardSize,
+      snapInfoColumnCount: snapInfoColumnCount,
+      totalWidth: totalWidth,
+    );
+  }
+}

--- a/lib/src/about/about_page.dart
+++ b/lib/src/about/about_page.dart
@@ -9,6 +9,7 @@ import 'package:yaru_widgets/yaru_widgets.dart';
 
 import '/constants.dart';
 import '/l10n.dart';
+import '/layout.dart';
 import '/widgets.dart';
 import 'about_providers.dart';
 

--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -9,8 +9,8 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/constants.dart';
 import '/l10n.dart';
+import '/layout.dart';
 import '/search.dart';
 import '/snapd.dart';
 import '/widgets.dart';

--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -70,8 +70,9 @@ class _SnapView extends ConsumerWidget {
         ),
       (
         label: l10n.detailPageLastUpdatedLabel,
-        value: DateFormat.yMd()
-            .format(model.localSnap?.installDate ?? channelInfo!.releasedAt)
+        value: channelInfo != null
+            ? DateFormat.yMd().format(channelInfo.releasedAt)
+            : '',
       ),
       (
         label: l10n.detailPageLicenseLabel,
@@ -83,59 +84,89 @@ class _SnapView extends ConsumerWidget {
       ),
     ];
 
-    return Column(
-      children: [
-        _Header(
-          model: model,
-          padding: const EdgeInsets.only(
-            left: kPagePadding,
-            right: kPagePadding,
-            top: kPagePadding,
-          ),
-        ),
-        Expanded(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: kPagePadding),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Wrap(
-                  spacing: 48,
-                  runSpacing: 8,
-                  children: snapInfos
-                      .map((info) => Column(
-                            children: [
-                              Text(
-                                info.label,
-                                style: Theme.of(context).textTheme.labelLarge,
-                              ),
-                              Text(info.value),
-                            ],
-                          ))
-                      .toList(),
-                ),
-                const Divider(),
-                if (model.storeSnap != null)
-                  _Section(
-                    header: Text(l10n.detailPageGalleryLabel),
-                    child: SnapScreenshotGallery(snap: model.storeSnap!),
-                  ),
-                _Section(
-                  header: Text(l10n.detailPageDescriptionLabel),
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: LayoutBuilder(builder: (context, constraints) {
+        final layout = ResponsiveLayout.fromConstraints(constraints);
+        return Column(
+          children: [
+            SizedBox(
+              width: layout.totalWidth,
+              child: _Header(model: model),
+            ),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Center(
                   child: SizedBox(
-                    width: double.infinity,
-                    child: MarkdownBody(
-                      data: model.storeSnap?.description ??
-                          model.localSnap?.description ??
-                          '',
+                    width: layout.totalWidth,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _SnapInfos(snapInfos: snapInfos, layout: layout),
+                        const Divider(),
+                        if (model.storeSnap != null)
+                          _Section(
+                            header: Text(l10n.detailPageGalleryLabel),
+                            child: SnapScreenshotGallery(
+                              snap: model.storeSnap!,
+                              height: layout.totalWidth / 2,
+                            ),
+                          ),
+                        _Section(
+                          header: Text(l10n.detailPageDescriptionLabel),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: MarkdownBody(
+                              data: model.storeSnap?.description ??
+                                  model.localSnap?.description ??
+                                  '',
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ),
-              ],
+              ),
             ),
-          ),
-        ),
-      ],
+          ],
+        );
+      }),
+    );
+  }
+}
+
+class _SnapInfos extends StatelessWidget {
+  const _SnapInfos({
+    required this.snapInfos,
+    required this.layout,
+  });
+
+  final List<SnapInfo> snapInfos;
+  final ResponsiveLayout layout;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: kPagePadding,
+      runSpacing: 8,
+      children: snapInfos
+          .map((info) => SizedBox(
+                width: (layout.totalWidth -
+                        (layout.snapInfoColumnCount - 1) * kPagePadding) /
+                    layout.snapInfoColumnCount,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      info.label,
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                    Text(info.value),
+                  ],
+                ),
+              ))
+          .toList(),
     );
   }
 }
@@ -220,7 +251,13 @@ class _ChannelDropdown extends YaruPopupMenuButton {
                     child: Text("${e.key} ${e.value.version}"),
                   ))
               .toList(),
-          child: Text("$selectedChannel ${channels[selectedChannel]!.version}"),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 200),
+            child: Text(
+              "$selectedChannel ${channels[selectedChannel]!.version}",
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
         );
 }
 
@@ -233,67 +270,66 @@ class _Section extends YaruExpandable {
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.model, this.padding});
+  const _Header({required this.model});
 
   final SnapModel model;
-  final EdgeInsets? padding;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final snap = model.storeSnap ?? model.localSnap!;
-    return Padding(
-      padding: padding ?? EdgeInsets.zero,
-      child: Column(
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const YaruBackButton(),
-              if (snap.website != null)
-                YaruIconButton(
-                  icon: const Icon(YaruIcons.share),
-                  onPressed: () {
-                    // TODO show snackbar
-                    Clipboard.setData(ClipboardData(text: snap.website!));
-                  },
-                ),
-            ],
-          ),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SnapIcon(iconUrl: snap.iconUrl, size: 96),
-              const SizedBox(width: 16),
-              Expanded(child: SnapTitle.large(snap: snap)),
-            ],
-          ),
-          const SizedBox(height: kPagePadding),
-          Row(
-            children: [
-              Text(
-                l10n.detailPageSelectChannelLabel,
-                style: Theme.of(context).textTheme.labelLarge,
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            const YaruBackButton(),
+            if (snap.website != null)
+              YaruIconButton(
+                icon: const Icon(YaruIcons.share),
+                onPressed: () {
+                  // TODO show snackbar
+                  Clipboard.setData(ClipboardData(text: snap.website!));
+                },
               ),
-              const SizedBox(width: 16),
-              if (model.availableChannels != null &&
-                  model.selectedChannel != null)
-                _ChannelDropdown(
-                  selectedChannel: model.selectedChannel!,
-                  channels: model.availableChannels!,
-                  onSelected: (value) => model.selectedChannel = value,
-                  enabled: model.activeChanges.isEmpty,
-                ),
-              const SizedBox(width: 16),
-              Flexible(
-                child: _SnapActionButtons(model: model),
-              )
-            ],
-          ),
-          const SizedBox(height: 42),
-          const Divider(),
-        ],
-      ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SnapIcon(iconUrl: snap.iconUrl, size: 96),
+            const SizedBox(width: 16),
+            Expanded(child: SnapTitle.large(snap: snap)),
+          ],
+        ),
+        const SizedBox(height: kPagePadding),
+        Row(
+          children: [
+            if (model.availableChannels != null &&
+                model.selectedChannel != null)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    l10n.detailPageSelectChannelLabel,
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                  const SizedBox(width: 16),
+                  _ChannelDropdown(
+                    selectedChannel: model.selectedChannel!,
+                    channels: model.availableChannels!,
+                    onSelected: (value) => model.selectedChannel = value,
+                    enabled: model.activeChanges.isEmpty,
+                  ),
+                ],
+              ),
+            Flexible(child: _SnapActionButtons(model: model))
+          ],
+        ),
+        const SizedBox(height: 42),
+        const Divider(),
+      ],
     );
   }
 }

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -6,8 +6,8 @@ import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/constants.dart';
 import '/l10n.dart';
+import '/layout.dart';
 import '/snapd.dart';
 import '/store.dart';
 import '/widgets.dart';

--- a/lib/src/search/search_page.dart
+++ b/lib/src/search/search_page.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ubuntu_widgets/ubuntu_widgets.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/constants.dart';
 import '/l10n.dart';
+import '/layout.dart';
 import '/store.dart';
 import '/widgets.dart';
 import 'search_provider.dart';

--- a/lib/src/store/store_app.dart
+++ b/lib/src/store/store_app.dart
@@ -3,9 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/constants.dart';
 import '/detail.dart';
 import '/l10n.dart';
+import '/layout.dart';
 import '/search.dart';
 import 'store_navigator.dart';
 import 'store_observer.dart';

--- a/lib/src/widgets/snap_card.dart
+++ b/lib/src/widgets/snap_card.dart
@@ -3,7 +3,7 @@ import 'package:snapd/snapd.dart';
 import 'package:yaru/yaru.dart';
 import 'package:yaru_widgets/yaru_widgets.dart';
 
-import '/constants.dart';
+import '/layout.dart';
 import '/snapd.dart';
 import '/widgets.dart';
 

--- a/lib/src/widgets/snap_grid.dart
+++ b/lib/src/widgets/snap_grid.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:snapd/snapd.dart';
 
-import '/constants.dart';
+import '/layout.dart';
 import 'snap_card.dart';
 
 class SnapGrid extends StatelessWidget {
@@ -13,25 +13,16 @@ class SnapGrid extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, constraints) {
-      final (columnCount, cardSize) =
-          switch (constraints.maxWidth + kPaneWidth + 1) {
-        // 1px for YaruNavigationRail's separator
-        < 1280 => (1, kCardSizeWide),
-        < 1680 => (2, kCardSizeNormal),
-        _ => (3, kCardSizeNormal),
-      };
-      final columnWidth = columnCount * cardSize.width +
-          (columnCount - 1) * (kPagePadding - kCardMargin) +
-          2 * kCardMargin;
+      final layout = ResponsiveLayout.fromConstraints(constraints);
       return GridView.builder(
         padding: EdgeInsets.symmetric(
-            horizontal: (constraints.maxWidth - columnWidth) / 2.0,
+            horizontal: (constraints.maxWidth - layout.totalWidth) / 2.0,
             vertical: kPagePadding + 4),
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: columnCount,
-          childAspectRatio: cardSize.aspectRatio,
-          mainAxisSpacing: kPagePadding - kCardMargin,
-          crossAxisSpacing: kPagePadding - kCardMargin,
+          crossAxisCount: layout.cardColumnCount,
+          childAspectRatio: layout.cardSize.aspectRatio,
+          mainAxisSpacing: kPagePadding - 2 * kCardMargin,
+          crossAxisSpacing: kPagePadding - 2 * kCardMargin,
         ),
         itemCount: snaps.length,
         itemBuilder: (context, index) {

--- a/lib/src/widgets/snap_icon.dart
+++ b/lib/src/widgets/snap_icon.dart
@@ -4,6 +4,7 @@ import 'package:shimmer/shimmer.dart';
 import 'package:yaru_icons/yaru_icons.dart';
 
 import '/constants.dart';
+import '/layout.dart';
 import '/xdg_cache_manager.dart';
 
 class SnapIcon extends StatelessWidget {

--- a/lib/src/widgets/snap_screenshot_gallery.dart
+++ b/lib/src/widgets/snap_screenshot_gallery.dart
@@ -9,14 +9,16 @@ import '/snapd.dart';
 import '/xdg_cache_manager.dart';
 
 class SnapScreenshotGallery extends StatelessWidget {
-  const SnapScreenshotGallery({super.key, required this.snap});
+  const SnapScreenshotGallery({super.key, required this.snap, this.height});
 
   final Snap snap;
+  final double? height;
 
   @override
   Widget build(BuildContext context) {
     return YaruCarousel(
-      height: 350,
+      height: height ?? 500,
+      width: double.infinity,
       nextIcon: const Icon(YaruIcons.go_next),
       previousIcon: const Icon(YaruIcons.go_previous),
       navigationControls: snap.screenshotUrls.length > 1,


### PR DESCRIPTION
UDENG-1048

First iteration on a responsive detail page whose width matches that of the grid of cards.

[Screencast from 2023-07-26 17-27-56.webm](https://github.com/ubuntu/app-store/assets/113362648/d6965c92-3338-4781-b151-243848273577)
