### PR TITLE
feat: add method to cancel ongoing change

### DIFF
--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -193,18 +193,18 @@ class _SnapActionButtons extends ConsumerWidget {
             model.selectedChannel != model.localSnap!.trackingChannel;
 
     final installRemoveButton = PushButton.elevated(
-      onPressed: model.activeChanges.isNotEmpty
+      onPressed: model.activeChangeId != null
           ? null
           : model.localSnap != null
               ? model.remove
               : () => model.install(),
-      child: model.activeChanges.isNotEmpty
+      child: model.activeChangeId != null
           ? Center(
               child: SizedBox.square(
                 dimension: IconTheme.of(context).size,
                 child: Consumer(builder: (context, ref, child) {
                   final progress = ref
-                      .watch(progressProvider(model.activeChanges))
+                      .watch(progressProvider([model.activeChangeId!]))
                       .whenOrNull(data: (data) => data);
                   return YaruCircularProgressIndicator(
                     value: progress,
@@ -325,7 +325,7 @@ class _Header extends StatelessWidget {
                     selectedChannel: model.selectedChannel!,
                     channels: model.availableChannels!,
                     onSelected: (value) => model.selectedChannel = value,
-                    enabled: model.activeChanges.isEmpty,
+                    enabled: model.activeChangeId == null,
                   ),
                 ],
               ),

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -51,7 +51,7 @@ SnapModel createMockSnapModel({
   when(model.availableChannels).thenReturn(storeSnap?.channels);
   when(model.selectedChannel).thenReturn(
       selectedChannel ?? localSnap?.trackingChannel ?? 'latest/stable');
-  when(model.activeChanges).thenReturn([]);
+  when(model.activeChangeId).thenReturn(null);
   return model;
 }
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -56,7 +56,7 @@ SnapModel createMockSnapModel({
 }
 
 @GenerateMocks([SnapdService])
-SnapdService createMockSnapdService({
+MockSnapdService createMockSnapdService({
   Snap? localSnap,
   Snap? storeSnap,
 }) {

--- a/test/test_utils.mocks.dart
+++ b/test/test_utils.mocks.dart
@@ -169,11 +169,6 @@ class MockSnapModel extends _i1.Mock implements _i4.SnapModel {
         returnValue: '',
       ) as String);
   @override
-  List<String> get activeChanges => (super.noSuchMethod(
-        Invocation.getter(#activeChanges),
-        returnValue: <String>[],
-      ) as List<String>);
-  @override
   set localSnap(_i2.Snap? _localSnap) => super.noSuchMethod(
         Invocation.setter(
           #localSnap,
@@ -233,6 +228,15 @@ class MockSnapModel extends _i1.Mock implements _i4.SnapModel {
   _i6.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
+          [],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+  @override
+  _i6.Future<void> cancel() => (super.noSuchMethod(
+        Invocation.method(
+          #cancel,
           [],
         ),
         returnValue: _i6.Future<void>.value(),


### PR DESCRIPTION
Assumes that there is only a single active change, triggered by the user.