### PR TITLE
feat: unify 'Published' labels, show abbr. month name

### DIFF
--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -73,10 +73,10 @@ class _SnapView extends ConsumerWidget {
         )
       ),
       (
-        label: l10n.detailPageReleasedAtLabel,
+        label: l10n.detailPagePublishedLabel,
         value: Text(
           snapModel.channelInfo != null
-              ? DateFormat.yMd().format(snapModel.channelInfo!.releasedAt)
+              ? DateFormat.yMMMd().format(snapModel.channelInfo!.releasedAt)
               : '',
         ),
       ),

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -17,7 +17,6 @@
     "detailPageLinksLabel": "Links",
     "detailPagePublisherLabel": "Publisher",
     "detailPagePublishedLabel": "Published",
-    "detailPageReleasedAtLabel": "Published on",
     "detailPageSummaryLabel": "Summary",
     "detailPageVersionLabel": "Version",
     "explorePageLabel": "Explore",

--- a/test/detail_page_test.dart
+++ b/test/detail_page_test.dart
@@ -4,6 +4,7 @@ import 'package:app_store/src/detail/detail_page.dart';
 import 'package:app_store/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
 import 'package:mockito/mockito.dart';
 import 'package:snapd/snapd.dart';
 import 'package:ubuntu_test/ubuntu_test.dart';
@@ -68,12 +69,15 @@ void expectSnapInfos(
   expect(find.text(tester.l10n.detailPageConfinementLabel), findsOneWidget);
   expect(find.text(tester.l10n.detailPageDescriptionLabel), findsOneWidget);
   expect(find.text(tester.l10n.detailPageLicenseLabel), findsOneWidget);
+  expect(find.text(tester.l10n.detailPagePublishedLabel), findsOneWidget);
 
   final snapChannel = snap.channels[channel];
   if (snapChannel != null) {
     expect(find.text(snapChannel.confinement.name), findsOneWidget);
     expect(find.text(tester.l10n.detailPageDownloadSizeLabel), findsOneWidget);
     expect(find.text(tester.context.formatByteSize(snapChannel.size)),
+        findsOneWidget);
+    expect(find.text(DateFormat.yMMMd().format(snapChannel.releasedAt)),
         findsOneWidget);
   }
 }


### PR DESCRIPTION
UDENG-1048

Shows "Published" date as e.g. "Aug 4, 2023" or "4 Aug 2023", depending on the locale