### PR TITLE
feat: generalize search provider to support 'category'

### DIFF
--- a/lib/src/search/search_page.dart
+++ b/lib/src/search/search_page.dart
@@ -58,7 +58,8 @@ class SearchPage extends StatelessWidget {
           ),
           Expanded(
             child: Consumer(builder: (context, ref, child) {
-              final results = ref.watch(sortedSearchProvider(query));
+              final results = ref.watch(
+                  sortedSearchProvider(SnapSearchParameters(query: query)));
               return results.when(
                 data: (data) => ResponsiveLayoutScrollView(
                   slivers: [

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,4 +1,5 @@
 import 'package:app_store/l10n.dart';
+import 'package:app_store/search.dart';
 import 'package:app_store/snapd.dart';
 import 'package:app_store/src/manage/manage_model.dart';
 import 'package:collection/collection.dart';
@@ -23,10 +24,14 @@ extension WidgetTesterX on WidgetTester {
   }
 }
 
-List<Snap> Function(String) createMockSearchProvider(
+List<Snap> Function(SnapSearchParameters) createMockSearchProvider(
     Map<String, List<Snap>> queries) {
-  return (String query) =>
-      queries.entries.firstWhereOrNull((e) => e.key.contains(query))?.value ??
+  return (SnapSearchParameters searchParameters) =>
+      queries.entries
+          .firstWhereOrNull((e) => searchParameters.query != null
+              ? e.key.contains(searchParameters.query!)
+              : false)
+          ?.value ??
       [];
 }
 


### PR DESCRIPTION
Preparation step to generalize the search page (links to a specific category on the explore page will open a general search page with an empty query and a pre-selected category filter).
Also: autodispose the search providers, as recommended [here](https://riverpod.dev/docs/concepts/modifiers/family#prefer-using-autodispose-when-the-parameter-is-not-constant).