### PR TITLE
fix: don't autodispose search providers

### DIFF
--- a/lib/src/search/search_provider.dart
+++ b/lib/src/search/search_provider.dart
@@ -21,15 +21,15 @@ class SnapSearchParameters {
   int get hashCode => Object.hash(query, category);
 }
 
-final searchProvider = FutureProvider.family
-    .autoDispose((ref, SnapSearchParameters searchParameters) {
+final searchProvider =
+    FutureProvider.family((ref, SnapSearchParameters searchParameters) {
   final snapd = getService<SnapdService>();
   return snapd.find(query: searchParameters.query);
 });
 
 final queryProvider = StateProvider<String>((_) => '');
 
-final autoCompleteProvider = FutureProvider.autoDispose((ref) async {
+final autoCompleteProvider = FutureProvider((ref) async {
   final query = ref.watch(queryProvider);
   final completer = Completer();
   ref.onDispose(completer.complete);


### PR DESCRIPTION
This seems to cause problems with the autocompletion - let's revert this for now and come back to it in case caching too many searches causes any issues in the future.