### PR TITLE
feat: import @Zoospora's banner gradients

### DIFF
--- a/lib/src/explore/explore_page.dart
+++ b/lib/src/explore/explore_page.dart
@@ -103,15 +103,21 @@ class _CategoryBanner extends ConsumerWidget {
     return _Banner(
       snaps: snaps,
       slogan: category.slogan(AppLocalizations.of(context)),
+      colors: category.bannerColors,
     );
   }
 }
 
 class _Banner extends StatelessWidget {
-  const _Banner({required this.snaps, required this.slogan});
+  const _Banner({
+    required this.snaps,
+    required this.slogan,
+    required this.colors,
+  });
 
   final Iterable<Snap> snaps;
   final String slogan;
+  final List<Color> colors;
 
   @override
   Widget build(BuildContext context) {
@@ -119,11 +125,8 @@ class _Banner extends StatelessWidget {
       padding: const EdgeInsets.all(48),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(8),
-        gradient: const LinearGradient(
-          colors: [
-            Color.fromARGB(255, 0, 5, 148),
-            Color.fromARGB(255, 255, 155, 179)
-          ],
+        gradient: LinearGradient(
+          colors: colors,
         ),
       ),
       height: 240,

--- a/lib/src/snapd/snap_category_enum.dart
+++ b/lib/src/snapd/snap_category_enum.dart
@@ -105,4 +105,53 @@ enum SnapCategoryEnum {
           selected ? YaruIcons.swiss_knife_filled : YaruIcons.swiss_knife,
         _ => YaruIcons.application,
       };
+
+  List<Color> get bannerColors => switch (this) {
+        development => _kBannerColors[9],
+        productivity => _kBannerColors[4],
+        _ => _kBannerColors[0]
+      };
 }
+
+const _kBannerColors = [
+  [
+    Color(0xff320a39),
+    Color(0xff0a737e),
+  ],
+  [
+    Color(0xff280684),
+    Color(0xff21bdb8),
+  ],
+  [
+    Color(0xff082435),
+    Color(0xff297068),
+  ],
+  [
+    Color(0xff271658),
+    Color(0xff3be173),
+  ],
+  [
+    Color(0xff12224b),
+    Color(0xffd27ed9),
+  ],
+  [
+    Color(0xff000594),
+    Color(0xffff9bb3),
+  ],
+  [
+    Color(0xff360050),
+    Color(0xffe13b95),
+  ],
+  [
+    Color(0xff30001a),
+    Color(0xfff90c71),
+  ],
+  [
+    Color(0xff700045),
+    Color(0xffe95420),
+  ],
+  [
+    Color(0xffb41601),
+    Color(0xfffeac0c),
+  ],
+];

--- a/lib/src/snapd/snap_category_enum.dart
+++ b/lib/src/snapd/snap_category_enum.dart
@@ -106,6 +106,7 @@ enum SnapCategoryEnum {
         _ => YaruIcons.application,
       };
 
+// TODO: map remaining categories to colors once the design is ready
   List<Color> get bannerColors => switch (this) {
         development => _kBannerColors[9],
         productivity => _kBannerColors[4],


### PR DESCRIPTION
Adds the accessibility-safe gradient colors for the banners from [here](https://github.com/ubuntu/app-store/discussions/1014#discussioncomment-4997933).
