### PR TITLE
feat(manage): show progress in 'update all' button

### DIFF
--- a/lib/snapd.dart
+++ b/lib/snapd.dart
@@ -1,4 +1,5 @@
 export 'src/snapd/snap_category_enum.dart';
+export 'src/snapd/snap_l10n.dart';
 export 'src/snapd/snap_launcher.dart';
 export 'src/snapd/snap_model.dart';
 export 'src/snapd/snapd_service.dart';

--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -509,20 +509,3 @@ class _ChannelDropdownEntry extends StatelessWidget {
     );
   }
 }
-
-extension SnapdChangeL10n on SnapdChange {
-  String? localize(AppLocalizations l10n) => switch (kind) {
-        'install-snap' => l10n.snapActionInstallingLabel,
-        'remove-snap' => l10n.snapActionRemovingLabel,
-        _ => null,
-      };
-}
-
-extension SnapConfinementL10n on SnapConfinement {
-  String localize(AppLocalizations l10n) => switch (this) {
-        SnapConfinement.classic => l10n.snapConfinementClassic,
-        SnapConfinement.devmode => l10n.snapConfinementDevmode,
-        SnapConfinement.strict => l10n.snapConfinementStrict,
-        _ => name,
-      };
-}

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -92,6 +92,7 @@
     "snapActionRemovingLabel": "Uninstalling",
     "snapActionSwitchChannelLabel": "Switch Channel",
     "snapActionUpdateLabel": "Update",
+    "snapActionUpdatingLabel": "Updating",
     "snapCategoryArtAndDesign": "Art and Design",
     "snapCategoryBooksAndReference": "Books and Reference",
     "snapCategoryDefaultButtonLabel": "Discover more",

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -153,9 +153,8 @@ class _ActionButtons extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         PushButton.outlined(
-          onPressed: updatesModel.activeChangeId != null
-              ? null
-              : ref.read(updatesModelProvider).refresh,
+          onPressed:
+              updatesModel.activeChangeId != null ? null : updatesModel.refresh,
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/src/snapd/snap_l10n.dart
+++ b/lib/src/snapd/snap_l10n.dart
@@ -5,6 +5,7 @@ import '/l10n.dart';
 extension SnapdChangeL10n on SnapdChange {
   String? localize(AppLocalizations l10n) => switch (kind) {
         'install-snap' => l10n.snapActionInstallingLabel,
+        'refresh-snap' => l10n.snapActionUpdatingLabel,
         'remove-snap' => l10n.snapActionRemovingLabel,
         _ => null,
       };

--- a/lib/src/snapd/snap_l10n.dart
+++ b/lib/src/snapd/snap_l10n.dart
@@ -1,0 +1,20 @@
+import 'package:snapd/snapd.dart';
+
+import '/l10n.dart';
+
+extension SnapdChangeL10n on SnapdChange {
+  String? localize(AppLocalizations l10n) => switch (kind) {
+        'install-snap' => l10n.snapActionInstallingLabel,
+        'remove-snap' => l10n.snapActionRemovingLabel,
+        _ => null,
+      };
+}
+
+extension SnapConfinementL10n on SnapConfinement {
+  String localize(AppLocalizations l10n) => switch (this) {
+        SnapConfinement.classic => l10n.snapConfinementClassic,
+        SnapConfinement.devmode => l10n.snapConfinementDevmode,
+        SnapConfinement.strict => l10n.snapConfinementStrict,
+        _ => name,
+      };
+}

--- a/test/detail_page_test.dart
+++ b/test/detail_page_test.dart
@@ -228,4 +228,6 @@ void main() {
     expect(find.text(tester.l10n.snapActionInstallLabel), findsNothing);
     expect(find.byType(YaruCircularProgressIndicator), findsOneWidget);
   });
+
+  // TODO: test loading states with snap change in progress
 }

--- a/test/manage_page_test.dart
+++ b/test/manage_page_test.dart
@@ -99,6 +99,8 @@ void main() {
     await tester.tap(openButton);
     verify(snapLauncher.open()).called(1);
   });
+
+  // TODO: test loading states with snap change in progress
 }
 
 extension on CommonFinders {

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -125,6 +125,7 @@ MockUpdatesModel createMockUpdatesModel(
   when(model.hasUpdate(any)).thenAnswer((i) =>
       refreshableSnapNames?.contains(i.positionalArguments.single) ?? false);
   when(model.state).thenReturn(AsyncValue.data(() {}()));
+  when(model.activeChangeId).thenReturn(null);
   return model;
 }
 


### PR DESCRIPTION
* Disable refresh button when an update is in progress
* Disable 'update all' button while checking for updates
* Show progress indicator in the 'update all' button during an update (similar to the primary action button on the detail page)
