### PR TITLE
feat: set default window size to 1280x800

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -37,8 +37,8 @@ static void my_application_activate(GApplication* application) {
   GdkGeometry geometry;
 
   // TODO: find better solution; set default window size based on available space
-  geometry.min_width = 852; // account for shadow from libhandy
-  geometry.min_height = 600;
+  geometry.min_width = 1280 + 52;  // account for shadow from libhandy
+  geometry.min_height = 800 + 52;
   gtk_window_set_geometry_hints(window, nullptr, &geometry, GDK_HINT_MIN_SIZE);
 
   gtk_window_set_default_size(window, 860, 860);


### PR DESCRIPTION
Note that the gtk window currently needs to be 52px larger in both directions to account for the shadow from libhandy.

![image](https://github.com/ubuntu/app-store/assets/113362648/e5bd7da9-87e2-4681-b6e8-c3cd0cda4eb3)
