### PR TITLE
fix: dropdown button only works once

### DIFF
--- a/lib/src/detail/detail_page.dart
+++ b/lib/src/detail/detail_page.dart
@@ -292,7 +292,13 @@ class _SnapActionButtons extends ConsumerWidget {
         );
       }).toList(),
       builder: (context, controller, child) => YaruOptionButton(
-        onPressed: controller.isOpen ? controller.close : controller.open,
+        onPressed: () {
+          if (controller.isOpen) {
+            controller.close();
+          } else {
+            controller.open();
+          }
+        },
         child: const Icon(YaruIcons.view_more_horizontal),
       ),
     );

--- a/lib/src/manage/manage_page.dart
+++ b/lib/src/manage/manage_page.dart
@@ -382,7 +382,13 @@ class _ManageSnapTile extends ConsumerWidget {
               )
             ],
             builder: (context, controller, child) => YaruOptionButton(
-              onPressed: controller.isOpen ? controller.close : controller.open,
+              onPressed: () {
+                if (controller.isOpen) {
+                  controller.close();
+                } else {
+                  controller.open();
+                }
+              },
               child: const Icon(YaruIcons.view_more_horizontal),
             ),
           )


### PR DESCRIPTION
Thanks to @gerwitz for spotting this! Clicking on the '...' dropdown buttons containing the secondary actions on the manage and app pages only works once.

Turns out [this](https://github.com/ubuntu/app-store/pull/1322#discussion_r1289682273) doesn't actually work, since the `YaruOptionButton` doesn't get rebuild when the controller state changes, so we have to pass a closure that explicitly checks the controller state.