### PR TITLE
feat: change icon to 'software-store'

### DIFF
--- a/assets/snap-store.desktop
+++ b/assets/snap-store.desktop
@@ -3,6 +3,6 @@ Type=Application
 Version=1.0
 Name=App Store
 Exec=snap-store %U
-Icon=snap-store
+Icon=software-store
 Terminal=false
 Categories=System;


### PR DESCRIPTION
Changes the application icon from [snap-store](https://github.com/ubuntu/yaru/blob/de539da6ca0fea00fe805a05ad6a208bc6943fd2/icons/src/fullcolor/default/apps/snap-store.svg) to [software-store](https://github.com/ubuntu/yaru/blob/de539da6ca0fea00fe805a05ad6a208bc6943fd2/icons/src/fullcolor/default/apps/software-store.svg)