### PR TITLE
feat: update explore page

### DIFF
--- a/lib/src/explore/explore_page.dart
+++ b/lib/src/explore/explore_page.dart
@@ -108,18 +108,23 @@ class _CategorySnapList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final categorySnaps = ref
+        // get snaps from `category`
         .watch(searchProvider(SnapSearchParameters(category: category)))
         .whenOrNull(data: (data) => data)
+        // .. without the banner snaps, if we don't want them
         ?.where(
           (snap) => hideBannerSnaps
               ? !(category.featuredSnapNames?.take(kNumberOfBannerSnaps) ?? [])
                   .contains(snap.name)
               : true,
         );
+
+    // pick hand-selected featured snaps
     final featuredSnaps = category.featuredSnapNames
         ?.map((name) =>
-            categorySnaps?.singleWhereOrNull(((snap) => snap.name == name)))
+            categorySnaps?.singleWhereOrNull((snap) => snap.name == name))
         .whereNotNull();
+
     final snaps = (onlyFeatured ? featuredSnaps : categorySnaps)
             ?.take(numberOfSnaps)
             .toList() ??

--- a/lib/src/explore/explore_provider.dart
+++ b/lib/src/explore/explore_provider.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:ubuntu_service/ubuntu_service.dart';
-
-import '/snapd.dart';
-
-final featuredProvider = StreamProvider.autoDispose((ref) {
-  final snapd = getService<SnapdService>();
-  return snapd.getCategory('featured');
-});

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -20,6 +20,7 @@
     "detailPageSummaryLabel": "Summary",
     "detailPageVersionLabel": "Version",
     "explorePageLabel": "Explore",
+    "explorePageCategoriesLabel": "Categories",
     "managePageCheckForUpdates": "Check for updates",
     "managePageCheckingForUpdates": "Checking for updates",
     "managePageDescription": "Check for available updates, update your apps, and manage the status of all your apps.",

--- a/lib/src/snapd/snap_category_enum.dart
+++ b/lib/src/snapd/snap_category_enum.dart
@@ -49,7 +49,7 @@ enum SnapCategoryEnum {
   List<String>? get featuredSnapNames => switch (this) {
         development => ['code', 'postman', 'phpstorm'],
         games => ['steam', 'discord', 'mc-installer', '0ad'],
-        productivity => ['chrome', 'wekan', 'firefox'],
+        productivity => ['chromium', 'wekan', 'firefox'],
         ubuntuDesktop => [
             'libreoffice',
             'thunderbird',


### PR DESCRIPTION
Final explore page updates with temporary workarounds, since we don't have any data for "What's new", "Top rated", and "Recently updated" yet. Instead we just show six snaps from a given category below the respective banners.

[Screencast from 2023-08-18 14-31-43.webm](https://github.com/ubuntu/app-store/assets/113362648/14e80a8a-0d2d-423e-9b8c-796e14968d15)
